### PR TITLE
Assign HTML lang attribute: zh-Hans-CN

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="zh-Hans-CN">
 <head>
     <meta charset="utf-8">
     <title>USTC Open Source Software Mirror</title>


### PR DESCRIPTION
This should help with font selection in Chromium-based browsers on MS Woe.
